### PR TITLE
fix: remove group filter from data sent/received queries

### DIFF
--- a/internal/grafana/dashboards/test-results.json
+++ b/internal/grafana/dashboards/test-results.json
@@ -502,7 +502,7 @@
                         "type": "influxdb",
                         "uid": "${DS_INFLUXDB}"
                     },
-                    "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => \n      r.testid == \"${testid}\" and \n      r.scenario =~ /${scenario:regex}/ and\n      r.group =~ /${group:regex}/ and\n      r.location =~ /${location:regex}/ \n  )\n  |> filter(fn: (r) => r._measurement == \"k6_data_received\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> group()\n  |> sum()",
+                    "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => \n      r.testid == \"${testid}\" and \n      r.scenario =~ /${scenario:regex}/ and\n      r.location =~ /${location:regex}/ \n  )\n  |> filter(fn: (r) => r._measurement == \"k6_data_received\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> group()\n  |> sum()",
                     "refId": "A"
                 }
             ],
@@ -565,7 +565,7 @@
                         "type": "influxdb",
                         "uid": "${DS_INFLUXDB}"
                     },
-                    "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => \n      r.testid == \"${testid}\" and \n      r.scenario =~ /${scenario:regex}/ and\n      r.group =~ /${group:regex}/ and\n      r.location =~ /${location:regex}/ \n  )\n  |> filter(fn: (r) => r._measurement == \"k6_data_sent\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> group()\n  |> sum()",
+                    "query": "from(bucket: \"${bucket}\")\n  |> range(start: v.timeRangeStart, stop:v.timeRangeStop)\n  |> filter(fn: (r) => \n      r.testid == \"${testid}\" and \n      r.scenario =~ /${scenario:regex}/ and\n      r.location =~ /${location:regex}/ \n  )\n  |> filter(fn: (r) => r._measurement == \"k6_data_sent\")\n  |> filter(fn: (r) => r._field == \"value\")\n  |> group()\n  |> sum()",
                     "refId": "A"
                 }
             ],


### PR DESCRIPTION
## Summary
- Remove group filter from Data Received and Data Sent dashboard queries

Counter metrics `k6_data_sent` and `k6_data_received` don't have a group tag, so filtering by group returns no data.

This fix was included in PR #71 (commit 7764bad) but was lost during the squash merge because PR #70 had already been merged with the earlier commits.

## Test plan
- [ ] Run a test with loadstorm.js and verify Data Received/Sent panels show values